### PR TITLE
Ability to easily configure the rx adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,13 @@ class Timer extends React.PureComponent {
 > }
 > export rxConnect(...)(MyView)
 > ```
+
+## Rx Support
+rxConnect is set up to use RxJS 4 by default. However, if you want to use RxJS 5 you can set it up like so:
+
+```javascript
+import { adapter, rx5Adapter } from "rx-connect";
+adapter.set(rx5Adapter);
+```
+
+Note that when using RxJS 5, the examples from this repository may not work.

--- a/src/__tests__/mapActionCreators-test.js
+++ b/src/__tests__/mapActionCreators-test.js
@@ -1,18 +1,18 @@
-import { mapActionCreators, rxConnect } from "../";
+import { mapActionCreators } from "../";
 import rx5Adapter from "../rx5Adapter";
-import { getAdapter } from "../rxConnect";
+import adapter from "../adapter";
 
 const suites = {
     "RxJS 4": () => {},
-    "RxJS 5": () => rxConnect.adapter = rx5Adapter
+    "RxJS 5": () => adapter.set(rx5Adapter)
 }
 
 Object.entries(suites).forEach(([ name, initializer ]) => describe(name, () => {
     let Rx;
     beforeEach(() => {
         initializer();
-        const adapter = getAdapter();
-        Rx = adapter.Rx;
+        const configuredAdapter = adapter.get();
+        Rx = configuredAdapter.Rx;
     });
 
     it("passes non-observables as is", async () => {

--- a/src/__tests__/rxConnect-test.js
+++ b/src/__tests__/rxConnect-test.js
@@ -3,19 +3,19 @@ import renderer from "react-test-renderer";
 
 import { rxConnect } from "../";
 import rx5Adapter from "../rx5Adapter";
-import { getAdapter } from "../rxConnect";
+import adapter from "../adapter";
 
 const suites = {
     "RxJS 4": () => {},
-    "RxJS 5": () => rxConnect.adapter = rx5Adapter
+    "RxJS 5": () => adapter.set(rx5Adapter)
 }
 
 Object.entries(suites).forEach(([ name, initializer ]) => describe(name, () => {
     let Rx;
     beforeEach(() => {
         initializer();
-        const adapter = getAdapter();
-        Rx = adapter.Rx;
+        const configuredAdapter = adapter.get();
+        Rx = configuredAdapter.Rx;
     });
 
     it("works with Observable", () => {

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -1,0 +1,6 @@
+let adapter = require("./rx4Adapter");
+
+export default {
+    get: () => adapter,
+    set: (newAdapter) => adapter = newAdapter,
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,5 @@
 export rxConnect from "./rxConnect";
 export mapActionCreators, { ofActions } from "./mapActionCreators";
+export adapter from "./adapter";
+export rx4Adapter from "./rx4Adapter";
+export rx5Adapter from "./rx5Adapter";

--- a/src/mapActionCreators.js
+++ b/src/mapActionCreators.js
@@ -1,4 +1,4 @@
-import { getAdapter } from "./rxConnect";
+import adapter from "./adapter";
 
 export function ofActions(actions) {
     return this.of(
@@ -9,7 +9,7 @@ export function ofActions(actions) {
 
                     if (key.endsWith("$")) {
                         result[key.slice(0, -1)] = (...args) => {
-                            getAdapter().next(action, args);
+                            adapter.get().next(action, args);
                         }
                     } else {
                         result[key] = action;
@@ -23,5 +23,5 @@ export function ofActions(actions) {
 }
 
 export default function mapActionCreators(actions) {
-    return getAdapter().Rx.Observable::ofActions(actions);
+    return adapter.get().Rx.Observable::ofActions(actions);
 }

--- a/src/rxConnect.js
+++ b/src/rxConnect.js
@@ -1,5 +1,6 @@
 import React from "react";
 import isPlainObject from "lodash.isplainobject";
+import adapter from "./adapter";
 
 const DEFAULT_OPTIONS = {
     noDebounce: false
@@ -13,11 +14,7 @@ function isObservable(obj) {
         return false;
     }
 
-    return getAdapter().isObservable(obj);
-}
-
-export function getAdapter() {
-    return rxConnect.adapter || require("./rx4Adapter");
+    return adapter.get().isObservable(obj);
 }
 
 export default function rxConnect(selector, options = DEFAULT_OPTIONS) {
@@ -34,11 +31,11 @@ export default function rxConnect(selector, options = DEFAULT_OPTIONS) {
         constructor(props) {
             super(props);
 
-            this.props$ = new (getAdapter().Rx.BehaviorSubject)(props);
+            this.props$ = new (adapter.get().Rx.BehaviorSubject)(props);
         }
 
         componentWillMount() {
-            const Rx = getAdapter().Rx;
+            const Rx = adapter.get().Rx;
             this.shouldDebounce = false;
 
             let mutations$ = selector;
@@ -89,11 +86,11 @@ export default function rxConnect(selector, options = DEFAULT_OPTIONS) {
         }
 
         componentWillUnmount() {
-            getAdapter().unsubscribe(this.stateSubscription);
+            adapter.get().unsubscribe(this.stateSubscription);
         }
 
         componentWillReceiveProps(nextProps) {
-            getAdapter().next(this.props$, nextProps);
+            adapter.get().next(this.props$, nextProps);
         }
 
         render() {


### PR DESCRIPTION
Currently in our code, for every component that uses rx-connect, we have to reset the adapter to use RxJS 5:

```javascript
import rx5Adapter from "rx-connect/lib/rx5Adapter";
rxConnect.adapter = rx5Adapter;
```

Problems:
* We have to import from an internal folder structure of rx-connect
* We have to repeat it for every component that uses rx-connect

The idea of this pull request is that we would only have to define the adapter once and then it would be applied for all components that use rx-connect:

```javascript
import { adapter, rx5Adapter } from "rx-connect";
adapter.set(rx5Adapter);
```

I also exported the `rx4Adapter`, though since it's the default one, perhaps it's not necessary.

Perhaps you have any better ideas on how to accomplish this? Maybe something like this could also work?

```javascript
import { useRx5Adapter } from "rx-connect";
useRx5Adapter();
```

Updated also the readme.

Also, have you considered switching to RxJS 5 by default? Some of the examples wouldn't work anymore though, so those would have to be updated!