### PR TITLE
require only rx4lite in runtime

### DIFF
--- a/src/rx4Adapter.js
+++ b/src/rx4Adapter.js
@@ -1,4 +1,4 @@
-import Rx from "rx";
+import Rx from "rx/dist/rx.lite";
 
 export default {
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,32 +1,13 @@
 var path = require("path");
 
-var reactExternal = {
-  root: 'React',
-  commonjs2: 'react',
-  commonjs: 'react',
-  amd: 'react'
-}
-
-var rxExternal = {
-  root: 'Rx',
-  commonjs2: 'rx',
-  commonjs: 'rx',
-  amd: 'rx'
-}
-
-var rxjsExternal = {
-  root: 'RxJS',
-  commonjs2: 'rxjs',
-  commonjs: 'rxjs',
-  amd: 'rxjs'
-}
-
 var config = {
-  externals: {
-    'react': reactExternal,
-    'rx': rxExternal,
-    'rxjs': rxjsExternal
-  },
+  externals: [
+    'react',
+    'rx',
+    'rx/dist/rx.lite',
+    'rxjs',
+    'rxjs/Rx',
+  ],
   output: {
     library: "RxConnect",
     libraryTarget: "umd"


### PR DESCRIPTION
fixes #6 

```
Asset     Size  Chunks             Chunk Names
rx-connect.min.js  16.4 kB       0  [emitted]  main
   [0] ./src/rxConnect.js 6.9 kB {0} [built]
   [1] ./src/mapActionCreators.js 931 bytes {0} [built]
   [2] ./src/rx4Adapter.js 622 bytes {0} [built]
   [3] ./~/lodash.isplainobject/index.js 3.67 kB {0} [built]
   [6] ./src/index.js 725 bytes {0} [built]
    + 2 hidden modules
```

seems not very useful optimization, as it already externalizes all dependencies, but this change  emphasize the requirements